### PR TITLE
Remove google play services from emulator

### DIFF
--- a/gms-toggle.bat
+++ b/gms-toggle.bat
@@ -2,185 +2,173 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 rem GMS Toggle Menu - Disable/Enable Google Play services (GMS) via ADB
-rem Run by double-click or from CMD in the same folder as adb.exe
+rem Run by double-click or from CMD; place next to adb.exe or add adb to PATH
 
-title GMS Toggle Menu
+title GMS Toggle Menu (Stable)
 
-set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
+set "SCRIPT_DIR=%~dp0"
+set "ADB_BIN=adb"
+if exist "%SCRIPT_DIR%adb.exe" set "ADB_BIN=%SCRIPT_DIR%adb.exe"
+
+%ADB_BIN% start-server >nul 2>&1
+
 set "TARGET="
-
-where adb >nul 2>&1
-if errorlevel 1 (
-  echo [ERROR] adb not found in PATH. Put this .bat next to adb.exe (platform-tools).
-  echo Press any key to exit...
-  pause >nul
-  exit /b 1
-)
-
-adb start-server >nul 2>&1
+call :print_header
 
 :menu
-cls
-echo ======================================================
-echo   GMS Toggle Menu - Google Play Services Controller
-echo ======================================================
-echo Target: %TARGET%
 echo.
-echo   1 ^) Disable Google Play services
-echo   2 ^) Enable Google Play services
-echo   3 ^) Show status
-echo   4 ^) Diagnose ADB and device info
-echo   5 ^) Change target (enter SERIAL or HOST:PORT)
-echo   0 ^) Exit
+echo [Target: %TARGET%]
 echo.
-set "CHOICE="
-set /p "CHOICE=Choose an option [0-5]: "
+echo  1) Disable Google Play services
+echo  2) Enable Google Play services
+echo  3) Show status
+echo  4) Diagnose
+echo  5) Change target (SERIAL or HOST:PORT)
+echo  0) Exit
+echo.
+choice /c 123450 /n /m "Select: "
+set "OPT=%errorlevel%"
+if "%OPT%"=="6" goto end
+if "%OPT%"=="5" goto change_target
+if "%OPT%"=="4" goto do_diag
+if "%OPT%"=="3" goto do_status
+if "%OPT%"=="2" goto do_enable
+if "%OPT%"=="1" goto do_disable
+goto menu
 
-if "%CHOICE%"=="1" goto do_disable
-if "%CHOICE%"=="2" goto do_enable
-if "%CHOICE%"=="3" goto do_status
-if "%CHOICE%"=="4" goto do_diag
-if "%CHOICE%"=="5" goto change_target
-if "%CHOICE%"=="0" goto end
-
-echo Invalid choice.
-echo Press any key to return to menu...
-pause >nul
+:ensure_adb
+rem Ensure adb exists either via explicit path or PATH
+if exist "%ADB_BIN%" goto :eof
+where adb >nul 2>&1 && goto :eof
+echo [ERROR] adb not found. Put this .bat next to adb.exe (platform-tools) or add to PATH.
+pause
 goto menu
 
 :ensure_connected
-rem Ensure there is a reachable ADB target; try auto-detect if empty.
+call :ensure_adb
 set "CONNECTED_OK=no"
 if "%TARGET%"=="" (
-  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do if "%%B"=="device" (
-    set "TARGET=%%A"
-    goto ec_try
+  for /f "skip=1 tokens=1,2" %%A in ('%ADB_BIN% devices') do (
+    if "%%B"=="device" (
+      set "TARGET=%%A"
+      goto ec_try
+    )
   )
-  for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do adb connect %%H >nul 2>&1
-  for /f "skip=1 tokens=1,2" %%C in ('adb devices') do if "%%D"=="device" (
-    set "TARGET=%%C"
-    goto ec_try
+  for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do %ADB_BIN% connect %%H >nul 2>&1
+  for /f "skip=1 tokens=1,2" %%C in ('%ADB_BIN% devices') do (
+    if "%%D"=="device" (
+      set "TARGET=%%C"
+      goto ec_try
+    )
   )
-  goto ec_no_device
+  echo [ERROR] No ADB device found.
+  pause
+  goto menu
 ) else (
   goto ec_try
 )
 
 :ec_try
-rem If TARGET contains a colon, try to connect to ensure binding.
-for /f "tokens=1,2 delims=:" %%X in ("%TARGET%") do set "_TMP_PORT=%%Y"
-if defined _TMP_PORT adb connect "%TARGET%" >nul 2>&1
-adb -s "%TARGET%" shell echo ok >nul 2>&1
-if errorlevel 1 goto ec_unreachable
+set "_has_port="
+for /f "tokens=1,2 delims=:" %%X in ("%TARGET%") do set "_has_port=%%Y"
+if defined _has_port %ADB_BIN% connect "%TARGET%" >nul 2>&1
+%ADB_BIN% -s "%TARGET%" shell echo ok >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] Cannot reach "%TARGET%".
+  pause
+  goto menu
+)
 set "CONNECTED_OK=yes"
 goto :eof
 
-:ec_no_device
-echo [ERROR] No ADB device found. Start your emulator or connect a device.
-echo Tip: Use option 5 to enter HOST:PORT (for example, 127.0.0.1:7555)
-echo Press any key to return to menu...
-pause >nul
-goto menu
-
-:ec_unreachable
-echo [ERROR] Unable to reach "%TARGET%" via ADB. Check ADB settings and port.
-echo Press any key to return to menu...
-pause >nul
-goto menu
+:packages_init
+set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
+goto :eof
 
 :do_disable
 call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
+call :packages_init
 cls
 echo Disabling/uninstalling Google packages for user 0 on %TARGET% ...
-for %%P in (%PACKAGES%) do call :disableOne %%P
+for %%P in (%PACKAGES%) do (
+  echo [*] %%P
+  %ADB_BIN% -s "%TARGET%" shell cmd package uninstall -k --user 0 %%P >nul 2>&1
+  if errorlevel 1 %ADB_BIN% -s "%TARGET%" shell pm uninstall -k --user 0 %%P >nul 2>&1
+  %ADB_BIN% -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
+)
 echo.
-echo Done. Recommended reboot: adb -s "%TARGET%" reboot
-echo.
-echo Press any key to return to menu...
-pause >nul
+echo Done. Recommended reboot: %ADB_BIN% -s "%TARGET%" reboot
+pause
 goto menu
-
-:disableOne
-echo ^>^> %~1
-adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %~1 >nul 2>&1
-if errorlevel 1 adb -s "%TARGET%" shell pm uninstall -k --user 0 %~1 >nul 2>&1
-adb -s "%TARGET%" shell pm disable-user --user 0 %~1 >nul 2>&1
-exit /b 0
 
 :do_enable
 call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
+call :packages_init
 cls
 echo Enabling/reinstalling Google packages for user 0 on %TARGET% ...
-for %%P in (%PACKAGES%) do call :enableOne %%P
+for %%P in (%PACKAGES%) do (
+  echo [*] %%P
+  %ADB_BIN% -s "%TARGET%" shell pm install-existing --user 0 %%P >nul 2>&1
+  %ADB_BIN% -s "%TARGET%" shell pm enable --user 0 %%P >nul 2>&1
+)
 echo.
-echo Done. You may reboot: adb -s "%TARGET%" reboot
-echo.
-echo Press any key to return to menu...
-pause >nul
+echo Done.
+pause
 goto menu
-
-:enableOne
-echo ^>^> %~1
-adb -s "%TARGET%" shell pm install-existing --user 0 %~1 >nul 2>&1
-adb -s "%TARGET%" shell pm enable --user 0 %~1 >nul 2>&1
-exit /b 0
 
 :do_status
 call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
+call :packages_init
 cls
 echo Package ^| Installed ^| Enabled
 echo --------------------------------
-for %%P in (%PACKAGES%) do call :statusOne %%P
-echo.
-echo Press any key to return to menu...
-pause >nul
+for %%P in (%PACKAGES%) do (
+  set "INST=no"
+  set "EN=n/a"
+  for /f "usebackq delims=" %%A in (`%ADB_BIN% -s "%TARGET%" shell pm list packages --user 0 ^| findstr /C:"package:%%P"`) do set "INST=yes"
+  if /i "!INST!"=="yes" (
+    set "EN=yes"
+    for /f "usebackq delims=" %%B in (`%ADB_BIN% -s "%TARGET%" shell pm list packages --user 0 -d ^| findstr /C:"package:%%P"`) do set "EN=no"
+  )
+  echo %%P ^| !INST! ^| !EN!
+)
+pause
 goto menu
 
-:statusOne
-set "INST=no"
-set "EN=n/a"
-for /f "usebackq delims=" %%A in (`adb -s "%TARGET%" shell pm list packages --user 0 ^| findstr /C:"package:%~1"`) do set "INST=yes"
-if /i "!INST!"=="yes" set "EN=yes"
-for /f "usebackq delims=" %%B in (`adb -s "%TARGET%" shell pm list packages --user 0 -d ^| findstr /C:"package:%~1"`) do set "EN=no"
-echo %~1 ^| !INST! ^| !EN!
-exit /b 0
-
 :do_diag
-call :ensure_connected
-if /i not "%CONNECTED_OK%"=="yes" goto menu
+call :ensure_adb
 cls
 echo === ADB Version ===
-adb version
+%ADB_BIN% version
 echo.
 echo === Devices ===
-adb devices
+%ADB_BIN% devices
 echo.
-echo === Target: %TARGET% ===
-adb -s "%TARGET%" shell getprop ro.product.manufacturer
-adb -s "%TARGET%" shell getprop ro.product.model
-adb -s "%TARGET%" shell getprop ro.build.version.release
-adb -s "%TARGET%" shell getprop ro.build.version.sdk
-echo.
-echo === GMS Presence ===
-adb -s "%TARGET%" shell pm path com.google.android.gms
-adb -s "%TARGET%" shell pm path com.google.android.gsf
-adb -s "%TARGET%" shell pm path com.android.vending
-echo.
-echo Press any key to return to menu...
-pause >nul
+if not "%TARGET%"=="" (
+  echo === Target: %TARGET% ===
+  %ADB_BIN% -s "%TARGET%" shell getprop ro.product.manufacturer
+  %ADB_BIN% -s "%TARGET%" shell getprop ro.product.model
+  %ADB_BIN% -s "%TARGET%" shell getprop ro.build.version.release
+  %ADB_BIN% -s "%TARGET%" shell getprop ro.build.version.sdk
+)
+pause
 goto menu
 
 :change_target
-cls
-echo Current target: %TARGET%
-set /p "TARGET=Enter SERIAL or HOST:PORT (example, 127.0.0.1:7555): "
-echo.
-echo Press any key to return to menu...
-pause >nul
+set /p "TARGET=Enter SERIAL or HOST:PORT (e.g., 127.0.0.1:7555): "
 goto menu
+
+:print_header
+cls
+echo ======================================================
+echo   GMS Toggle Menu - Google Play Services Controller
+echo ======================================================
+echo Put this .bat next to adb.exe or add adb to PATH.
+echo.
+goto :eof
 
 :end
 echo Exiting...

--- a/gms-toggle.bat
+++ b/gms-toggle.bat
@@ -1,100 +1,149 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
-rem gms-toggle.bat - Disable/Enable Google Play (GMS) packages via ADB
-rem Usage: gms-toggle.bat [disable|enable|status|diag] [SERIAL_OR_HOST:PORT]
-rem If target is omitted, the script auto-detects the first connected device.
+title GMS Toggle Menu (Disable/Enable Google Play Services)
 
-set "ACTION=%~1"
-set "TARGET=%~2"
+rem Usage: Double-click or run in CMD. Script shows a numbered menu.
+rem Requires: adb in PATH or place this .bat next to adb.exe (platform-tools)
 
-if /i "%ACTION%"=="" (
-  echo Usage: %~nx0 [disable^|enable^|status^|diag] [SERIAL_OR_HOST:PORT]
-  exit /b 1
-)
+set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
+set "TARGET="
 
 where adb >nul 2>&1
 if errorlevel 1 (
-  echo Error: adb not found in PATH. Install Platform-Tools or run from its folder.
+  echo [ERROR] adb not found in PATH. Put this .bat next to adb.exe (platform-tools).
+  echo Press any key to exit...
+  pause >nul
   exit /b 1
 )
 
 adb start-server >nul 2>&1
 
-rem Auto-detect device if TARGET not provided
+:menu
+cls
+echo ======================================================
+echo   GMS Toggle Menu - Google Play Services Controller
+echo ======================================================
+echo Target: %TARGET%
+echo.
+echo   1 ^) Disable Google Play services (GMS)
+echo   2 ^) Enable Google Play services (GMS)
+echo   3 ^) Show status (installed/enabled)
+echo   4 ^) Diagnose (ADB ^& device info)
+echo   5 ^) Change target (enter SERIAL or HOST:PORT)
+echo   0 ^) Exit
+echo.
+set "CHOICE="
+set /p "CHOICE=Choose an option [0-5]: "
+
+if "%CHOICE%"=="1" goto do_disable
+if "%CHOICE%"=="2" goto do_enable
+if "%CHOICE%"=="3" goto do_status
+if "%CHOICE%"=="4" goto do_diag
+if "%CHOICE%"=="5" goto change_target
+if "%CHOICE%"=="0" goto end
+
+echo Invalid choice.
+echo Press any key to return to menu...
+pause >nul
+goto menu
+
+:ensure_connected
+rem Auto-detect device if TARGET is empty; else ensure reachable
+set "CONNECTED_OK=no"
 if "%TARGET%"=="" (
+  rem Try to pick first 'device' from adb devices
   for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
     if "%%B"=="device" (
       set "TARGET=%%A"
-      goto :got_target
+      goto :ec_try_connect
     )
   )
-  rem Try connecting to common emulator endpoints
+  rem Try common emulator endpoints
   for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do (
     adb connect %%H >nul 2>&1
   )
   for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
     if "%%B"=="device" (
       set "TARGET=%%A"
-      goto :got_target
+      goto :ec_try_connect
     )
   )
-  echo No ADB device found. Connect your emulator or pass [SERIAL_OR_HOST:PORT].
-  exit /b 1
+  goto :ec_no_device
+) else (
+  goto :ec_try_connect
 )
 
-:got_target
-adb -s "%TARGET%" shell echo ok >nul 2>&1
+:ec_try_connect
+rem If target looks like HOST:PORT, try adb connect to ensure binding
+for /f "delims=: tokens=1,2" %%H in ("%TARGET%") do set "_has_port=%%I"
+if defined _has_port (
+  adb connect "%TARGET%" >nul 2>&1
+)
+adb -s "%TARGET%" shell exit >nul 2>&1
 if errorlevel 1 (
-  echo Unable to reach "%TARGET%" via ADB. Ensure ADB is enabled and the port is correct.
-  exit /b 1
+  goto :ec_unreachable
 )
+set "CONNECTED_OK=yes"
+goto :eof
 
-set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
+:ec_no_device
+echo [ERROR] No ADB device found. Start your emulator or connect a device.
+echo Tip: Use option 5 to enter HOST:PORT (e.g., 127.0.0.1:7555)
+echo Press any key to return to menu...
+pause >nul
+goto menu
 
-if /i "%ACTION%"=="disable" goto :do_disable
-if /i "%ACTION%"=="enable" goto :do_enable
-if /i "%ACTION%"=="status" goto :do_status
-if /i "%ACTION%"=="diag" goto :do_diag
-
-echo Unknown action: %ACTION%
-echo Usage: %~nx0 [disable^|enable^|status^|diag] [SERIAL_OR_HOST:PORT]
-exit /b 1
+:ec_unreachable
+echo [ERROR] Unable to reach "%TARGET%" via ADB.
+echo Ensure ADB is enabled on the emulator and the port is correct.
+echo Press any key to return to menu...
+pause >nul
+goto menu
 
 :do_disable
+call :ensure_connected
+if /i not "%CONNECTED_OK%"=="yes" goto menu
+cls
 echo Disabling/uninstalling Google packages for user 0 on %TARGET% ...
 for %%P in (%PACKAGES%) do (
   echo ^>^> %%P
-  rem Try modern uninstall command first
   adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %%P >nul 2>&1
   if errorlevel 1 (
-    rem Fallback to legacy pm uninstall for user
     adb -s "%TARGET%" shell pm uninstall -k --user 0 %%P >nul 2>&1
   )
-  rem If uninstall not possible, attempt disabling
   adb -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
-  rem As a last resort, try set-disabled using cmd package (older/newer APIs)
-  adb -s "%TARGET%" shell cmd package set-enabled --user 0 false %%P >nul 2>&1
 )
-echo Done. Consider reboot: adb -s "%TARGET%" reboot
-exit /b 0
+echo.
+echo Done. It is recommended to reboot: adb -s "%TARGET%" reboot
+echo.
+echo Press any key to return to menu...
+pause >nul
+goto menu
 
 :do_enable
+call :ensure_connected
+if /i not "%CONNECTED_OK%"=="yes" goto menu
+cls
 echo Enabling/reinstalling Google packages for user 0 on %TARGET% ...
 for %%P in (%PACKAGES%) do (
   echo ^>^> %%P
-  rem Re-install existing system apps for user 0 if hidden
   adb -s "%TARGET%" shell pm install-existing --user 0 %%P >nul 2>&1
-  rem Enable via both pm and cmd package for wider compatibility
   adb -s "%TARGET%" shell pm enable --user 0 %%P >nul 2>&1
-  adb -s "%TARGET%" shell cmd package set-enabled --user 0 true %%P >nul 2>&1
 )
+echo.
 echo Done. You may reboot: adb -s "%TARGET%" reboot
-exit /b 0
+echo.
+echo Press any key to return to menu...
+pause >nul
+goto menu
 
 :do_status
+call :ensure_connected
+if /i not "%CONNECTED_OK%"=="yes" goto menu
+cls
 echo Package ^| Installed ^| Enabled
-echo ------------------------------
+echo --------------------------------
 for %%P in (%PACKAGES%) do (
   set "INST=no"
   set "EN=n/a"
@@ -105,10 +154,16 @@ for %%P in (%PACKAGES%) do (
   )
   echo %%P ^| !INST! ^| !EN!
 )
-exit /b 0
+echo.
+echo Press any key to return to menu...
+pause >nul
+goto menu
 
 :do_diag
-echo === ADB Info ===
+call :ensure_connected
+if /i not "%CONNECTED_OK%"=="yes" goto menu
+cls
+echo === ADB Version ===
 adb version
 echo.
 echo === Devices ===
@@ -125,5 +180,20 @@ adb -s "%TARGET%" shell pm path com.google.android.gms
 adb -s "%TARGET%" shell pm path com.google.android.gsf
 adb -s "%TARGET%" shell pm path com.android.vending
 echo.
-echo Tip: If no device, pass explicit HOST:PORT, e.g. 127.0.0.1:7555
+echo Press any key to return to menu...
+pause >nul
+goto menu
+
+:change_target
+cls
+echo Current target: %TARGET%
+set /p "TARGET=Enter SERIAL or HOST:PORT (e.g., 127.0.0.1:7555): "
+echo.
+echo Press any key to return to menu...
+pause >nul
+goto menu
+
+:end
+echo Exiting...
+timeout /t 1 >nul
 exit /b 0

--- a/gms-toggle.bat
+++ b/gms-toggle.bat
@@ -1,10 +1,10 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
-title GMS Toggle Menu (Disable/Enable Google Play Services)
+rem GMS Toggle Menu - Disable/Enable Google Play services (GMS) via ADB
+rem Run by double-click or from CMD in the same folder as adb.exe
 
-rem Usage: Double-click or run in CMD. Script shows a numbered menu.
-rem Requires: adb in PATH or place this .bat next to adb.exe (platform-tools)
+title GMS Toggle Menu
 
 set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
 set "TARGET="
@@ -26,10 +26,10 @@ echo   GMS Toggle Menu - Google Play Services Controller
 echo ======================================================
 echo Target: %TARGET%
 echo.
-echo   1 ^) Disable Google Play services (GMS)
-echo   2 ^) Enable Google Play services (GMS)
-echo   3 ^) Show status (installed/enabled)
-echo   4 ^) Diagnose (ADB ^& device info)
+echo   1 ^) Disable Google Play services
+echo   2 ^) Enable Google Play services
+echo   3 ^) Show status
+echo   4 ^) Diagnose ADB and device info
 echo   5 ^) Change target (enter SERIAL or HOST:PORT)
 echo   0 ^) Exit
 echo.
@@ -49,54 +49,41 @@ pause >nul
 goto menu
 
 :ensure_connected
-rem Auto-detect device if TARGET is empty; else ensure reachable
+rem Ensure there is a reachable ADB target; try auto-detect if empty.
 set "CONNECTED_OK=no"
 if "%TARGET%"=="" (
-  rem Try to pick first 'device' from adb devices
-  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
-    if "%%B"=="device" (
-      set "TARGET=%%A"
-      goto :ec_try_connect
-    )
+  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do if "%%B"=="device" (
+    set "TARGET=%%A"
+    goto ec_try
   )
-  rem Try common emulator endpoints
-  for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do (
-    adb connect %%H >nul 2>&1
+  for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do adb connect %%H >nul 2>&1
+  for /f "skip=1 tokens=1,2" %%C in ('adb devices') do if "%%D"=="device" (
+    set "TARGET=%%C"
+    goto ec_try
   )
-  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
-    if "%%B"=="device" (
-      set "TARGET=%%A"
-      goto :ec_try_connect
-    )
-  )
-  goto :ec_no_device
+  goto ec_no_device
 ) else (
-  goto :ec_try_connect
+  goto ec_try
 )
 
-:ec_try_connect
-rem If target looks like HOST:PORT, try adb connect to ensure binding
-for /f "delims=: tokens=1,2" %%H in ("%TARGET%") do set "_has_port=%%I"
-if defined _has_port (
-  adb connect "%TARGET%" >nul 2>&1
-)
-adb -s "%TARGET%" shell exit >nul 2>&1
-if errorlevel 1 (
-  goto :ec_unreachable
-)
+:ec_try
+rem If TARGET contains a colon, try to connect to ensure binding.
+for /f "tokens=1,2 delims=:" %%X in ("%TARGET%") do set "_TMP_PORT=%%Y"
+if defined _TMP_PORT adb connect "%TARGET%" >nul 2>&1
+adb -s "%TARGET%" shell echo ok >nul 2>&1
+if errorlevel 1 goto ec_unreachable
 set "CONNECTED_OK=yes"
 goto :eof
 
 :ec_no_device
 echo [ERROR] No ADB device found. Start your emulator or connect a device.
-echo Tip: Use option 5 to enter HOST:PORT (e.g., 127.0.0.1:7555)
+echo Tip: Use option 5 to enter HOST:PORT (for example, 127.0.0.1:7555)
 echo Press any key to return to menu...
 pause >nul
 goto menu
 
 :ec_unreachable
-echo [ERROR] Unable to reach "%TARGET%" via ADB.
-echo Ensure ADB is enabled on the emulator and the port is correct.
+echo [ERROR] Unable to reach "%TARGET%" via ADB. Check ADB settings and port.
 echo Press any key to return to menu...
 pause >nul
 goto menu
@@ -106,31 +93,27 @@ call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
 cls
 echo Disabling/uninstalling Google packages for user 0 on %TARGET% ...
-for %%P in (%PACKAGES%) do (
-  echo ^>^> %%P
-  adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %%P >nul 2>&1
-  if errorlevel 1 (
-    adb -s "%TARGET%" shell pm uninstall -k --user 0 %%P >nul 2>&1
-  )
-  adb -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
-)
+for %%P in (%PACKAGES%) do call :disableOne %%P
 echo.
-echo Done. It is recommended to reboot: adb -s "%TARGET%" reboot
+echo Done. Recommended reboot: adb -s "%TARGET%" reboot
 echo.
 echo Press any key to return to menu...
 pause >nul
 goto menu
+
+:disableOne
+echo ^>^> %~1
+adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %~1 >nul 2>&1
+if errorlevel 1 adb -s "%TARGET%" shell pm uninstall -k --user 0 %~1 >nul 2>&1
+adb -s "%TARGET%" shell pm disable-user --user 0 %~1 >nul 2>&1
+exit /b 0
 
 :do_enable
 call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
 cls
 echo Enabling/reinstalling Google packages for user 0 on %TARGET% ...
-for %%P in (%PACKAGES%) do (
-  echo ^>^> %%P
-  adb -s "%TARGET%" shell pm install-existing --user 0 %%P >nul 2>&1
-  adb -s "%TARGET%" shell pm enable --user 0 %%P >nul 2>&1
-)
+for %%P in (%PACKAGES%) do call :enableOne %%P
 echo.
 echo Done. You may reboot: adb -s "%TARGET%" reboot
 echo.
@@ -138,26 +121,32 @@ echo Press any key to return to menu...
 pause >nul
 goto menu
 
+:enableOne
+echo ^>^> %~1
+adb -s "%TARGET%" shell pm install-existing --user 0 %~1 >nul 2>&1
+adb -s "%TARGET%" shell pm enable --user 0 %~1 >nul 2>&1
+exit /b 0
+
 :do_status
 call :ensure_connected
 if /i not "%CONNECTED_OK%"=="yes" goto menu
 cls
 echo Package ^| Installed ^| Enabled
 echo --------------------------------
-for %%P in (%PACKAGES%) do (
-  set "INST=no"
-  set "EN=n/a"
-  for /f "usebackq delims=" %%A in (`adb -s "%TARGET%" shell pm list packages --user 0 ^| findstr /C:"package:%%P"`) do set "INST=yes"
-  if "!INST!"=="yes" (
-    set "EN=yes"
-    for /f "usebackq delims=" %%B in (`adb -s "%TARGET%" shell pm list packages --user 0 -d ^| findstr /C:"package:%%P"`) do set "EN=no"
-  )
-  echo %%P ^| !INST! ^| !EN!
-)
+for %%P in (%PACKAGES%) do call :statusOne %%P
 echo.
 echo Press any key to return to menu...
 pause >nul
 goto menu
+
+:statusOne
+set "INST=no"
+set "EN=n/a"
+for /f "usebackq delims=" %%A in (`adb -s "%TARGET%" shell pm list packages --user 0 ^| findstr /C:"package:%~1"`) do set "INST=yes"
+if /i "!INST!"=="yes" set "EN=yes"
+for /f "usebackq delims=" %%B in (`adb -s "%TARGET%" shell pm list packages --user 0 -d ^| findstr /C:"package:%~1"`) do set "EN=no"
+echo %~1 ^| !INST! ^| !EN!
+exit /b 0
 
 :do_diag
 call :ensure_connected
@@ -187,7 +176,7 @@ goto menu
 :change_target
 cls
 echo Current target: %TARGET%
-set /p "TARGET=Enter SERIAL or HOST:PORT (e.g., 127.0.0.1:7555): "
+set /p "TARGET=Enter SERIAL or HOST:PORT (example, 127.0.0.1:7555): "
 echo.
 echo Press any key to return to menu...
 pause >nul

--- a/gms-toggle.bat
+++ b/gms-toggle.bat
@@ -1,0 +1,78 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem gms-toggle.bat - Disable/Enable Google Play (GMS) packages via ADB
+rem Usage: gms-toggle.bat [disable|enable|status] [HOST:PORT]
+rem Default HOST:PORT = 127.0.0.1:7555 (e.g., MuMu)
+
+set "ACTION=%~1"
+set "TARGET=%~2"
+if "%TARGET%"=="" set "TARGET=127.0.0.1:7555"
+
+if /i "%ACTION%"=="disable" goto have_action
+if /i "%ACTION%"=="enable" goto have_action
+if /i "%ACTION%"=="status" goto have_action
+
+echo Usage: %~nx0 [disable^|enable^|status] [HOST:PORT]
+exit /b 1
+
+:have_action
+where adb >nul 2>&1
+if errorlevel 1 (
+  echo Error: adb not found in PATH.
+  exit /b 1
+)
+
+adb start-server >nul 2>&1
+adb connect "%TARGET%" >nul 2>&1
+
+adb -s "%TARGET%" shell exit >nul 2>&1
+if errorlevel 1 (
+  echo Unable to reach %TARGET% via ADB.
+  exit /b 1
+)
+
+set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
+
+if /i "%ACTION%"=="disable" goto do_disable
+if /i "%ACTION%"=="enable" goto do_enable
+if /i "%ACTION%"=="status" goto do_status
+
+goto :eof
+
+:do_disable
+echo Disabling/uninstalling Google packages for user 0 on %TARGET% ...
+for %%P in (%PACKAGES%) do (
+  echo ^>^> %%P
+  adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %%P >nul 2>&1
+  if errorlevel 1 (
+    adb -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
+  )
+)
+echo Done. Consider reboot: adb -s "%TARGET%" reboot
+exit /b 0
+
+:do_enable
+echo Enabling/reinstalling Google packages for user 0 on %TARGET% ...
+for %%P in (%PACKAGES%) do (
+  echo ^>^> %%P
+  adb -s "%TARGET%" shell pm install-existing --user 0 %%P >nul 2>&1
+  adb -s "%TARGET%" shell pm enable --user 0 %%P >nul 2>&1
+)
+echo Done. You may reboot: adb -s "%TARGET%" reboot
+exit /b 0
+
+:do_status
+echo Package ^| Installed ^| Enabled
+echo ------------------------------
+for %%P in (%PACKAGES%) do (
+  set "INST=no"
+  set "EN=n/a"
+  for /f "usebackq delims=" %%A in (`adb -s "%TARGET%" shell pm list packages --user 0 ^| findstr /C:"package:%%P"`) do set "INST=yes"
+  if "!INST!"=="yes" (
+    set "EN=yes"
+    for /f "usebackq delims=" %%B in (`adb -s "%TARGET%" shell pm list packages --user 0 -d ^| findstr /C:"package:%%P"`) do set "EN=no"
+  )
+  echo %%P ^| !INST! ^| !EN!
+)
+exit /b 0

--- a/gms-toggle.bat
+++ b/gms-toggle.bat
@@ -2,52 +2,79 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 rem gms-toggle.bat - Disable/Enable Google Play (GMS) packages via ADB
-rem Usage: gms-toggle.bat [disable|enable|status] [HOST:PORT]
-rem Default HOST:PORT = 127.0.0.1:7555 (e.g., MuMu)
+rem Usage: gms-toggle.bat [disable|enable|status|diag] [SERIAL_OR_HOST:PORT]
+rem If target is omitted, the script auto-detects the first connected device.
 
 set "ACTION=%~1"
 set "TARGET=%~2"
-if "%TARGET%"=="" set "TARGET=127.0.0.1:7555"
 
-if /i "%ACTION%"=="disable" goto have_action
-if /i "%ACTION%"=="enable" goto have_action
-if /i "%ACTION%"=="status" goto have_action
+if /i "%ACTION%"=="" (
+  echo Usage: %~nx0 [disable^|enable^|status^|diag] [SERIAL_OR_HOST:PORT]
+  exit /b 1
+)
 
-echo Usage: %~nx0 [disable^|enable^|status] [HOST:PORT]
-exit /b 1
-
-:have_action
 where adb >nul 2>&1
 if errorlevel 1 (
-  echo Error: adb not found in PATH.
+  echo Error: adb not found in PATH. Install Platform-Tools or run from its folder.
   exit /b 1
 )
 
 adb start-server >nul 2>&1
-adb connect "%TARGET%" >nul 2>&1
 
-adb -s "%TARGET%" shell exit >nul 2>&1
+rem Auto-detect device if TARGET not provided
+if "%TARGET%"=="" (
+  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
+    if "%%B"=="device" (
+      set "TARGET=%%A"
+      goto :got_target
+    )
+  )
+  rem Try connecting to common emulator endpoints
+  for %%H in (127.0.0.1:7555 127.0.0.1:5555 127.0.0.1:62001 127.0.0.1:21503 127.0.0.1:5557) do (
+    adb connect %%H >nul 2>&1
+  )
+  for /f "skip=1 tokens=1,2" %%A in ('adb devices') do (
+    if "%%B"=="device" (
+      set "TARGET=%%A"
+      goto :got_target
+    )
+  )
+  echo No ADB device found. Connect your emulator or pass [SERIAL_OR_HOST:PORT].
+  exit /b 1
+)
+
+:got_target
+adb -s "%TARGET%" shell echo ok >nul 2>&1
 if errorlevel 1 (
-  echo Unable to reach %TARGET% via ADB.
+  echo Unable to reach "%TARGET%" via ADB. Ensure ADB is enabled and the port is correct.
   exit /b 1
 )
 
 set "PACKAGES=com.google.android.gms com.google.android.gsf com.android.vending com.google.android.gsf.login com.google.android.syncadapters.calendar com.google.android.syncadapters.contacts com.google.android.onetimeinitializer com.google.android.backuptransport com.google.android.feedback com.google.android.configupdater com.google.android.partnersetup com.google.android.setupwizard com.google.android.apps.restore"
 
-if /i "%ACTION%"=="disable" goto do_disable
-if /i "%ACTION%"=="enable" goto do_enable
-if /i "%ACTION%"=="status" goto do_status
+if /i "%ACTION%"=="disable" goto :do_disable
+if /i "%ACTION%"=="enable" goto :do_enable
+if /i "%ACTION%"=="status" goto :do_status
+if /i "%ACTION%"=="diag" goto :do_diag
 
-goto :eof
+echo Unknown action: %ACTION%
+echo Usage: %~nx0 [disable^|enable^|status^|diag] [SERIAL_OR_HOST:PORT]
+exit /b 1
 
 :do_disable
 echo Disabling/uninstalling Google packages for user 0 on %TARGET% ...
 for %%P in (%PACKAGES%) do (
   echo ^>^> %%P
+  rem Try modern uninstall command first
   adb -s "%TARGET%" shell cmd package uninstall -k --user 0 %%P >nul 2>&1
   if errorlevel 1 (
-    adb -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
+    rem Fallback to legacy pm uninstall for user
+    adb -s "%TARGET%" shell pm uninstall -k --user 0 %%P >nul 2>&1
   )
+  rem If uninstall not possible, attempt disabling
+  adb -s "%TARGET%" shell pm disable-user --user 0 %%P >nul 2>&1
+  rem As a last resort, try set-disabled using cmd package (older/newer APIs)
+  adb -s "%TARGET%" shell cmd package set-enabled --user 0 false %%P >nul 2>&1
 )
 echo Done. Consider reboot: adb -s "%TARGET%" reboot
 exit /b 0
@@ -56,8 +83,11 @@ exit /b 0
 echo Enabling/reinstalling Google packages for user 0 on %TARGET% ...
 for %%P in (%PACKAGES%) do (
   echo ^>^> %%P
+  rem Re-install existing system apps for user 0 if hidden
   adb -s "%TARGET%" shell pm install-existing --user 0 %%P >nul 2>&1
+  rem Enable via both pm and cmd package for wider compatibility
   adb -s "%TARGET%" shell pm enable --user 0 %%P >nul 2>&1
+  adb -s "%TARGET%" shell cmd package set-enabled --user 0 true %%P >nul 2>&1
 )
 echo Done. You may reboot: adb -s "%TARGET%" reboot
 exit /b 0
@@ -75,4 +105,25 @@ for %%P in (%PACKAGES%) do (
   )
   echo %%P ^| !INST! ^| !EN!
 )
+exit /b 0
+
+:do_diag
+echo === ADB Info ===
+adb version
+echo.
+echo === Devices ===
+adb devices
+echo.
+echo === Target: %TARGET% ===
+adb -s "%TARGET%" shell getprop ro.product.manufacturer
+adb -s "%TARGET%" shell getprop ro.product.model
+adb -s "%TARGET%" shell getprop ro.build.version.release
+adb -s "%TARGET%" shell getprop ro.build.version.sdk
+echo.
+echo === GMS Presence ===
+adb -s "%TARGET%" shell pm path com.google.android.gms
+adb -s "%TARGET%" shell pm path com.google.android.gsf
+adb -s "%TARGET%" shell pm path com.android.vending
+echo.
+echo Tip: If no device, pass explicit HOST:PORT, e.g. 127.0.0.1:7555
 exit /b 0


### PR DESCRIPTION
Add `gms-toggle.bat` script to enable/disable Google Play Services on Android emulators via ADB.

---
<a href="https://cursor.com/background-agent?bcId=bc-69389baf-b837-4c3f-815d-7368095e1b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69389baf-b837-4c3f-815d-7368095e1b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

